### PR TITLE
Update base.install

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -27,7 +27,7 @@ ORIG=$(cd $(dirname $0); pwd)
 . functions
 
 check_binary() {
-	type -p $1 || { fatal_error "$1 is missing"; >&2; exit 1; }
+	type -p $1 || { fatal_error "$1 is missing" >&2; exit 1; }
 }
 
 init_redhat_chroot() {
@@ -270,7 +270,7 @@ if [ $? -eq 0 ]; then
     echo "Exiting"
     exit 1
 fi
-
+# I dont think this will work as set -e is sourced above from the file functions
 set -e              # abort on failure
 set -x              # print commands
 


### PR DESCRIPTION
moving the set -e below the check_binary breaks the check_binary function. Best practice, never use set -e and if it is used it goes at top of the script.
