### PR TITLE
Rename function update_repository to update_repositories in upgrade scri...

### DIFF
--- a/build/upgrade-from.d/base_D6-F.1.0.0_D6-F.1.0.1.upgrade
+++ b/build/upgrade-from.d/base_D6-F.1.0.0_D6-F.1.0.1.upgrade
@@ -27,5 +27,5 @@ export DEBIAN_FRONTEND=noninteractive
 . common
 set -x
 
-update_repository $TDIR
+update_repositories $TDIR
 update_system $TDIR

--- a/build/upgrade-from.d/base_D7-F.1.0.0_D7-F.1.0.1.upgrade
+++ b/build/upgrade-from.d/base_D7-F.1.0.0_D7-F.1.0.1.upgrade
@@ -27,5 +27,5 @@ export DEBIAN_FRONTEND=noninteractive
 . common
 set -x
 
-update_repository $TDIR
+update_repositories $TDIR
 update_system $TDIR

--- a/build/upgrade-from.d/base_U12.04-F.1.0.0_U12.04-F.1.0.1.upgrade
+++ b/build/upgrade-from.d/base_U12.04-F.1.0.0_U12.04-F.1.0.1.upgrade
@@ -27,5 +27,5 @@ export DEBIAN_FRONTEND=noninteractive
 . common
 set -x
 
-update_repository $TDIR
+update_repositories $TDIR
 update_system $TDIR


### PR DESCRIPTION
...pts

The function update_repository was called in the base upgrade scripts but
seems to not be defined anywhere, plus the mysql upgrade script uses
update_repositories. I suspect it was a left over during a function rename.
