### PR TITLE
base.install: Remove check on dh_testdir

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -261,7 +261,6 @@ fi
 
 check_variables
 
-check_binary dh_testdir
 check_binary wget
 check_binary debootstrap
 check_binary chroot


### PR DESCRIPTION
dh_testdir is not used anymore on eDeploy and this check is preventing
eDeploy to be deployed on non-debian operating systems.
