### PR TITLE
upgrade-from.d: Remove redundant call to update_repositories

### DIFF
--- a/build/upgrade-from.d/base_D6-F.1.0.0_D6-F.1.0.1.upgrade
+++ b/build/upgrade-from.d/base_D6-F.1.0.0_D6-F.1.0.1.upgrade
@@ -27,5 +27,4 @@ export DEBIAN_FRONTEND=noninteractive
 . common
 set -x
 
-update_repositories $TDIR
 update_system $TDIR

--- a/build/upgrade-from.d/base_D7-F.1.0.0_D7-F.1.0.1.upgrade
+++ b/build/upgrade-from.d/base_D7-F.1.0.0_D7-F.1.0.1.upgrade
@@ -27,5 +27,4 @@ export DEBIAN_FRONTEND=noninteractive
 . common
 set -x
 
-update_repositories $TDIR
 update_system $TDIR

--- a/build/upgrade-from.d/base_U12.04-F.1.0.0_U12.04-F.1.0.1.upgrade
+++ b/build/upgrade-from.d/base_U12.04-F.1.0.0_U12.04-F.1.0.1.upgrade
@@ -27,5 +27,4 @@ export DEBIAN_FRONTEND=noninteractive
 . common
 set -x
 
-update_repositories $TDIR
 update_system $TDIR

--- a/build/upgrade-from.d/mysql_D7-F.1.0.0_D7-F.1.0.1.upgrade
+++ b/build/upgrade-from.d/mysql_D7-F.1.0.0_D7-F.1.0.1.upgrade
@@ -29,5 +29,4 @@ export DEBIAN_FRONTEND=noninteractive
 
 set -x
 
-update_repositories $dir
 install_packages $dir mysql-server-5.5 apache2


### PR DESCRIPTION
A call to update_repositories is already made on the calling function
upgrade-from(l138).
