### PR TITLE
Refine check that prevented CentOS from installing

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -37,7 +37,7 @@ init_redhat_chroot() {
     local rpm_repository="$REPOSITORY"
     local next_repository=""
 
-    if [ -z $REPOSITORY ] && [ -z $ISO_PATH ];then
+    if [ "$(dist)" = "redhat" ] && [ -z $REPOSITORY ] && [ -z $ISO_PATH ];then
         fatal_error "You must set your repository in the variable REPOSITORY or the ISO path in the ISO_PATH variable."
     fi
 


### PR DESCRIPTION
During 2d1ef0c8 a check was introduced that was RedHat specific.
The condition of the check were not specific enough and applied to
CentOS preventing it to install. This commit specifies that this check
is for RedHat only.
