### PR TITLE
Allow you to use int or str in state file.

### DIFF
--- a/server/upload.py
+++ b/server/upload.py
@@ -407,7 +407,7 @@ def main():
     times = '*'
     name = None
     for name, times in names:
-        if times == '*' or times > 0:
+        if times == '*' or int(times) > 0:
             specs = eval(open(cfg_dir + name + '.specs', 'r').read(-1))
             var = {}
             var2 = {}
@@ -423,7 +423,7 @@ def main():
         var2 = var
 
     if times != '*':
-        names[idx] = (name, times - 1)
+        names[idx] = (name, int(times) - 1)
 
     cmdb = load_cmdb(cfg_dir, name)
     if cmdb:


### PR DESCRIPTION
Allow you to use int or str in state file for times section like :

```
[('hp', '4'), ('vm-centos', '*'), ('vm-debian', '3'), ('kvm-test', '0')]
```

This patch ensure times is an int.

Traceback if you are using str without this patch :

```
Traceback (most recent call last):
  File "/usr/lib/cgi-bin/upload.py", line 482, in &lt;module&gt;
    main()
  File "/usr/lib/cgi-bin/upload.py", line 426, in main
    names[idx] = (name, times - 1)
TypeError: unsupported operand type(s) for -: 'str' and 'int'
```
