### PR TITLE
build: Disable DNS reverse lookup for SSH daemon

### DIFF
--- a/build/init.common
+++ b/build/init.common
@@ -175,6 +175,7 @@ update_ssh_port() {
     sed -i -e 's/^.*Port.*$/Port 2222/' /etc/ssh/sshd_config
     sed -i -e 's/^.*#PermitRootLogin.*$/PermitRootLogin yes/' /etc/ssh/sshd_config
     sed -i -e 's/^.*#PermitEmptyPasswords.*$/PermitEmptyPasswords yes/' /etc/ssh/sshd_config
+    echo 'UseDNS no' >> /etc/ssh/sshd_config
 }
 
 start_ssh_server() {


### PR DESCRIPTION
This commit disable the DNS reverse-lookup on SSH debug daemon.
