### PR TITLE
U/Mount /dev instead of rsync/rm

### DIFF
--- a/build/common
+++ b/build/common
@@ -189,10 +189,6 @@ clean_mount_points() {
         return
     fi
 
-    # Since /dev is a copy, we shall clean it as it will be reconstructed at boot time
-    rm -rf ${dir}/dev
-    mkdir -p ${dir}/dev
-
     a=10
     local lazy=""
 
@@ -212,6 +208,9 @@ clean_mount_points() {
             return 1
         fi
     done
+
+    # add dev dir if does exist
+    mkdir -p ${dir}/dev
 
     return 0
 }

--- a/build/create-image.sh
+++ b/build/create-image.sh
@@ -51,7 +51,7 @@ fi
 }
 
 clean_temporary() {
-    rm -rf "$MDIR/"dev
+    umount "$MDIR/"dev
     umount "$MDIR/"proc
     umount "$MDIR"
 
@@ -157,11 +157,8 @@ trap do_cleanup 0
 
 rsync -a "$DIR/" "$MDIR/"
 
-# Let's create a copy of the current /dev
-mkdir -p "${MDIR}/"/dev/pts
-rsync -a --delete-before --exclude=shm /dev/ ${MDIR}/dev/
-
-# Mount /proc
+# Mount nested /dev and /proc
+mount -o bind /dev "$MDIR/"dev
 mount -t proc none "$MDIR/"proc
 
 # Configure Grub


### PR DESCRIPTION
This commit:
- puts back the mount/umount of dev
- moved the mkdir of /dev after the potential lazy umount. In case
  the umount fails, the script returns 1.
