### PR TITLE
Use http.debian.org instead of cdn.debian.org

### DIFF
--- a/build/repositories
+++ b/build/repositories
@@ -8,7 +8,7 @@ add_main_repository() {
 
   case "$dist" in
     $supported_debian_dists)
-        echo "http://cdn.debian.net/debian"
+        echo "http://http.debian.net/debian"
         return 0
     ;;
     $supported_ubuntu_dists)


### PR DESCRIPTION
According to http://http.debian.net/ this redirector has a lower chance
of an inconsistency. One of these inconsistencies is an expired Release
file, which makes it impossible to execute "apt-get update" because it fails.
