### PR TITLE
Do not remove the directory /dev

### DIFF
--- a/build/create-image.sh
+++ b/build/create-image.sh
@@ -51,7 +51,7 @@ fi
 }
 
 clean_temporary() {
-    rm -rf "$MDIR/"dev
+    rm -rf "$MDIR/"dev/*
     umount "$MDIR/"proc
     umount "$MDIR"
 


### PR DESCRIPTION
Removing /dev directory sometimes prevent the image to
boot, udev will not create the /dev directory but only
the content.

This patch only remove the content of /dev.
