### PR TITLE
If ORIG is not exported, common will fail.

### DIFF
--- a/build/upgrade-from
+++ b/build/upgrade-from
@@ -140,7 +140,8 @@ cp -p ${ORIG}/edeploy ${TDIR}/usr/sbin/
 script="$BASE".d/${ROLE}_${FROM}_${TO}.upgrade
 
 if [ -x "$script" ]; then
-    dir=$TDIR "$script"
+    dir=$TDIR 
+    . "$script"
 fi
 
 setup_metadata


### PR DESCRIPTION
When running the update script, the ORIG variable
wasn't passed on to common, and the update would
fail to build.

This patch exports ORIG so common can see it.
