### PR TITLE
Fix log rotation

### DIFF
--- a/build/policy-rc.d
+++ b/build/policy-rc.d
@@ -20,4 +20,6 @@ script="$1"
 actions="$2"
 level="$3"
 
-exit 101
+if [ $actions != rotate ]; then
+    exit 101
+fi


### PR DESCRIPTION
Log rotation doesn't work since we deny the execution of rc.
The line `invoke-rc.d rsyslog rotate > /dev/null` doesn't work.

Closes: #53
