### PR TITLE
doc: add missing dep on curl

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,7 +37,8 @@ You will need the following dependencies to be able to run the test-suite::
 
  apt-get install python-openstack.nose-plugin python-mock \
    python-netaddr debootstrap qemu-kvm qemu-utils \
-   python-ipaddr libfrontier-rpc-perl curl libfrontier-rpc-perl
+   python-ipaddr libfrontier-rpc-perl curl libfrontier-rpc-perl \
+   yum-utils
 
 It may be a good idea to install these additional dependencies too::
 


### PR DESCRIPTION
rpm calls rpm to retrieve to grab rpm over HTTP. That's something
we do to bootstrap the base install.
