### PR TITLE
Added check curl (required by {redhat,centos} builds)

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -305,6 +305,7 @@ check_binary wget
 check_binary debootstrap
 check_binary chroot
 check_binary sed
+check_binary curl
 
 uname -m | grep -q 'i[3-6]86'
 if [ $? -eq 0 ]; then


### PR DESCRIPTION
If curl package is missing on build server, {redhat,centos} builds
fail with a not explicate message from rpm.

rpm: RPM should not be used directly install RPM packages, use Alien
instead!

Closes: #65
