### PR TITLE
Add backslash to BOOT_ARG otherwise cloud-init is not working.

### DIFF
--- a/build/init
+++ b/build/init
@@ -241,7 +241,7 @@ if /configure; then
 
         if [ -n "${METADATA_URL}" ]; then
             log "Setting up cloudinit with METADATAURL=$METADATA_URL"
-            BOOT_ARG="$BOOT_ARG ds=nocloud-net;s=${METADATA_URL}"
+            BOOT_ARG="$BOOT_ARG ds=nocloud-net\\\;s=${METADATA_URL}"
         else
             log "No METADATA_URL variable found, no cloud-init configuration done"
         fi


### PR DESCRIPTION
Hi,

We need to add backslash between "ds=nocloud-net" and ";s=${METADATA_URL}" otherwise $METADATA_URL is not populated in /proc/cmdline and cloud-init is not working.

For exemple, without:
`BOOT_IMAGE=/vmlinuz-3.12-0.bpo.1-amd64 root=/dev/mapper/rootfs-slash ro console=tty0 console=ttyS1,115200n8 ds=nocloud-net`

And with backslash:
`BOOT_IMAGE=/vmlinuz-3.12-0.bpo.1-amd64 root=/dev/mapper/rootfs-slash ro console=tty0 console=ttyS1,115200n8 ds=nocloud-net;s=http://10.153.19.10/`

In my previous use it was working, I don't know when this bug has appeared.

Thanks in advance.
