### PR TITLE
Force creation of /var/tmp

### DIFF
--- a/build/deploy.install
+++ b/build/deploy.install
@@ -73,8 +73,10 @@ install_edeploy() {
     cd pxemngr/ansible
     # do not start apache in the chroot
     sed -e 's@service apache2 restart@/bin/true@' < pxemngr-install.yml > pxemngr-install2.yml
+    # /var/tmp/ is mandatory for django manage syncdb
+    [ ! -d "$dir/var/tmp" ] && mkdir $dir/var/tmp
     ansible-playbook -c chroot -i $t pxemngr-install2.yml
-    rm -f pxemngr-install2.yml
+    rm -f $t pxemngr-install2.yml
     popd
 
     # edeploy part


### PR DESCRIPTION
- /var/tmp is mandatory for django manage.py syncdb
- Fix temp file removal
