### PR TITLE
deploy: Install eNovance GPG key in deploy server

### DIFF
--- a/build/deploy.install
+++ b/build/deploy.install
@@ -36,6 +36,13 @@ check_os() {
     esac
 }
 
+case "$OS" in
+    "Debian"|"Ubuntu")
+        # Install eNovance maintainers key
+        do_chroot $dir apt-key adv --keyserver keyserver.ubuntu.com --recv E52660B15D964F0B
+    ;;
+esac
+
 generate_ansible_host() {
     file=$1
     section=$2


### PR DESCRIPTION
We provide python-pip and python-crypto in eNovance repository (with a
newer version than wheezy/trusty), the install of this package cause an
error (unauthenticated package if the eNovance key isn't present.
