### PR TITLE
build/packages: improve pkg listing

### DIFF
--- a/build/packages
+++ b/build/packages
@@ -14,10 +14,10 @@ array_diff() {
 save_package_list() {
     case $(package_type) in
         "deb")
-            do_chroot ${dir} dpkg -l > ${INST}/${ROLE}.packages
+            do_chroot ${dir} dpkg -l | grep '^ii' | awk '{print $2 "\t" $3}' > ${INST}/${ROLE}.packages
             ;;
         "rpm")
-            do_chroot ${dir} rpm -qa > ${INST}/${ROLE}.packages
+            do_chroot ${dir} rpm -qa --queryformat '%{NAME} %{VERSION}-%{RELEASE}\n' > ${INST}/${ROLE}.packages
             ;;
         *)
             fatal_error "Unsupported package_type ($package_type) in save_package_list()"


### PR DESCRIPTION
When building the role.packages with packages list, use a standard
output to be able to parse it from external tools.
The use-case: check the upgrades / downgrades between releases.

Example of output on RH / CentOS:
libcurl 7.29.0
libasyncns 0.8
perl-Net-LibIDN 0.12
dbus 1.6.12
fence-agents-common 4.0.2

Example of output on Debian / Ubuntu:
xtrans-dev  1.3.2-1
xul-ext-ubufox  2.9-0ubuntu0.14.04.1
xul-ext-unity 3.0.0+14.04.20140416-0ubuntu1
xul-ext-webaccounts 0.5-0ubuntu

Output syntax is: <PACKAGE_NAME> <VERSION>
