### PR TITLE
tools: add pkg-diff script

### DIFF
--- a/tools/pkg-diff.sh
+++ b/tools/pkg-diff.sh
@@ -64,12 +64,20 @@ deleted_pkg() {
 }
 
 version_pkg() {
+  printf '%-25s %25s %25s\n' "Package name" "Previous version" "Newer version"
+  printf '%-25s %-25s %-25s\n' "-------------------------" "-------------------------" "-------------------------"
   for pkg in $new_package_names; do
       old_version=$(grep $pkg $OLD_LIST | awk '{print $2}')
       new_version=$(grep $pkg $NEW_LIST | awk '{print $2}')
       if [ -n $old_version ] && [ "$old_version" != "$new_version" ]; then
-          echo "old: $pkg $old_version"
-          echo "new: $pkg $new_version"
+
+          # If the package was not existing in previous relase
+          # Let's add a N/A as the previous version, and show the new one in new_version
+          if [ -z "$old_version" ]; then
+              old_version="N/A"
+          fi
+
+          printf '%-25s %25s %25s\n' "$pkg" "$old_version" "$new_version"
       fi
   done
 }


### PR DESCRIPTION
Compare two list of packages and show the differences.
Expected syntax of file:
<package_name> <version>

Use:
diff-pkg old.packages new.packages

To generate the list of packages:
- Red Hat / CentOS: rpm -qa --queryformat '%{NAME} %{VERSION}'
- Debian / Ubuntu: dpkg -l | grep '^ii' | awk '{print $2 "\t" $3}'

Note: the package list generation is done by eDeploy in build/packages.
