### PR TITLE
tools/jenkins-build: compare packages from last release

### DIFF
--- a/tools/jenkins-build.sh
+++ b/tools/jenkins-build.sh
@@ -49,6 +49,8 @@ for role in $ROLES; do
 	    mkdir -p "$ARCH"/$VERS/
 	    sudo rsync -a "$DIR"/install/$VERS/*.* "$ARCH"/$VERS/
 	    git rev-parse HEAD > "$ARCH"/$VERS/$role.rev
+            OLD=$(git describe --abbrev=0 --tags)
+            $DIR/tools/pkg-diff.sh $ARCH/$DVER-$OLD/$role.packages $ARCH/$VERS/$role.packages > $SRC/$DVER-$role-diff
 	fi
     else
 	BROKEN="$BROKEN $role"


### PR DESCRIPTION
For each roles which is building, create a file which contains the
differences between the last release and the current one.
This file is generated by pkg-diff.sh script already merged.
