### PR TITLE
apache configuration: Follow symlinks for upload.py

### DIFF
--- a/ansible/edeploy-apache.conf
+++ b/ansible/edeploy-apache.conf
@@ -1,0 +1,21 @@
+NameVirtualHost *:80
+Listen 80
+
+<VirtualHost *:80>
+  ServerAdmin webmaster@localhost
+  
+  DocumentRoot /var/www/cgi-bin
+  <Directory "/var/www/cgi-bin">
+    Options Indexes FollowSymlinks MultiViews ExecCGI
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+    AddHandler cgi-script .cgi .py
+  </Directory>
+  
+  ErrorLog /var/log/apache2/error-edeploy.log
+  # Possible values include: debug, info, notice, warn, error, crit,
+  # alert, emerg.
+  LogLevel warn
+  CustomLog /var/log/apache2/access-edeploy.log combined
+</VirtualHost>

--- a/ansible/edeploy-httpd.conf
+++ b/ansible/edeploy-httpd.conf
@@ -1,0 +1,18 @@
+<VirtualHost *:80>
+  ServerAdmin webmaster@localhost
+  
+  DocumentRoot /var/www/cgi-bin
+  <Directory "/var/www/cgi-bin">
+    Options Indexes FollowSymlinks MultiViews ExecCGI
+    AllowOverride None
+    Order allow,deny
+    Allow from all
+    AddHandler cgi-script .cgi .py
+  </Directory>
+  
+  ErrorLog /var/log/httpd/error-edeploy.log
+  # Possible values include: debug, info, notice, warn, error, crit,
+  # alert, emerg.
+  LogLevel warn
+  CustomLog /var/log/httpd/access-edeploy.log combined
+</VirtualHost>

--- a/ansible/edeploy-install.yml
+++ b/ansible/edeploy-install.yml
@@ -111,6 +111,14 @@
     template: src=edeploy.prof dest=/var/lib/tftpboot/pxelinux.cfg/profiles/edeploy.prof mode=0644
     notify: sync bootnames
     when: pxemngr
+  - name: enable edeploy site in apache (deb)
+    copy: src=edeploy-apache.conf dest=/etc/apache2/sites-available/edeploy
+    notify: enable edeploy site (deb)
+    when: ansible_distribution == 'Debian' or ansible_distribution == 'Ubuntu'
+  - name: enable edeploy site in apache (rhel)
+    copy: src=edeploy-httpd.conf dest=/etc/httpd/conf.d/edeploy.conf
+    notify: enable edeploy site (rhel)
+    when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
   - name: install eDeploy AHC profile in pxemngr
     template: src=health-check.prof dest=/var/lib/tftpboot/pxelinux.cfg/profiles/health-check.prof mode=0644
     notify: sync bootnames
@@ -123,3 +131,7 @@
       command: pxemngr nextboot default edeploy
     - name: start rsync daemon
       service: name=rsync state=started
+    - name: enable edeploy site (deb)
+      shell: a2ensite edeploy; service apache2 restart
+    - name: enable edeploy site (rhel)
+      shell: systemctl restart httpd.service


### PR DESCRIPTION
Currently because upload.py is a symlink it is not downloaded.
This patch fix that applying the correct apache configuration.
