### PR TITLE
openstack/common: Disable package even when enable isnt the first keyword

### DIFF
--- a/build/packages
+++ b/build/packages
@@ -111,9 +111,9 @@ EOF
                 do_chroot ${chroot} mv /usr/bin/systemctl /usr/bin/systemctl.save
                 cat >> ${chroot}/usr/bin/systemctl << EOF
 #!/bin/bash
-if echo \$1 | egrep -q '^(enable|disable)$'; then
-    shift
-    systemctl.save disable \$* || exit 1
+if echo \$* | egrep -q '(enable|disable) '; then
+    new_arg_line=`echo \$* | sed 's/\(enable\|disable\) /disable /g'`
+    systemctl.save \$new_arg_line || exit 1
 fi
 EOF
                 chmod +x ${chroot}/usr/bin/systemctl


### PR DESCRIPTION
Currently, services are disabled only if enable or disable is the first
keywork in the systemctl command. For example : 

```
  systemctl enable myservice.service
```

Unfortunately, enable or disable isn't always the first word. For example,
Puppet enable its service with this command :

```
  systemctl --no-reload enable puppet.service
```

Hence the current script does not work anymore. This patch makes the
`install_packages_disabled` works no matter where is the enable keyword
located.
