### PR TITLE
tools/virt.conf: build image in QCOW2 instead of RAW

### DIFF
--- a/tools/virt.conf
+++ b/tools/virt.conf
@@ -1,5 +1,5 @@
 # allow to replace existing vm images
 REPLACE=1
 
-# default image format to raw
-IMAGE_FORMAT=raw
+# default image format to qcow2
+IMAGE_FORMAT=qcow2


### PR DESCRIPTION
Change the default virt.conf to build QCOW2 images instead of heavy RAW.
