### PR TITLE
base: Label objects on the first boot and put SELinux in permissive

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -229,6 +229,8 @@ install_base_packages() {
             # don't rename net ifaces
             ln -s /dev/null $dir/etc/udev/rules.d/80-net-name-slot.rules
         fi
+        touch ${target}/.autorelabel
+        sed -i 's/SELINUX=.*/SELINUX=permissive/' ${target}/etc/selinux/config
     fi
 }
 


### PR DESCRIPTION
By default objects (files,processes,sockets) are not labeled with a
context, hence they don't have a type. This does not allow us to start
with SELinux set to Enforced the first time, so on the first boot
we label everything (touch /.autorelabel) not enforcing SELinux.
Later, the operator or the configuration management tool will
come and set SELinux to Enforced.
