### PR TITLE
Fix scoping issue ($target not available)

### DIFF
--- a/build/repositories
+++ b/build/repositories
@@ -240,7 +240,7 @@ add_rhn_repository() {
                 return
             fi
 
-            if [ ! -f "$target/etc/sysconfig/rhn/systemid" ]; then
+            if [ ! -f "$dir/etc/sysconfig/rhn/systemid" ]; then
                 case "$CODENAME_MAJOR" in
                     6)
                         install_packages $dir rhn-setup


### PR DESCRIPTION
This is a follow on from 10a084ebc70417f48801c99610d1f9a60a16c793

because $target is out of scope this then checks to see if the host system is registered, not the chroot.  So use $dir instead
