### PR TITLE
Disable yum plugins during the redhat chroot bootstrap

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -78,7 +78,7 @@ init_redhat_chroot() {
     rebuild_db_with_local $target
     rpm --root="$target" --import $(ls $target/etc/pki/rpm-gpg/RPM-GPG-KEY-* | fgrep -v Debug)
     # We cannot use install_packages since the basesystem isn't yet setup
-    yum --installroot $target install -y basesystem yum
+    yum --disableplugin=* --installroot $target install -y basesystem yum
 
     case "$dist" in
         redhat)


### PR DESCRIPTION
When running yum from outside the chroot (using --installroot) and the rhnplugin or subscription-manager plugins are active then it's possible for yum to pull in extra packages.

This can then result in the chroot containing newer versions of RPMs like glibc which then prevents subscription-manager from being installed when it needs one of the glibc sub-packages (way down in the dependency trees).
