### PR TITLE
Only attempt to mount the ISO image if it isn't already mounted

### DIFF
--- a/build/common
+++ b/build/common
@@ -370,7 +370,7 @@ mount_fs() {
         if [ ! -d ${dir}/repo ]; then
             mkdir -p ${dir}/repo
         fi
-        mount -o loop $ISO_PATH "${dir}/repo"
+        mountpoint -q ${dir}/repo || mount -o loop $ISO_PATH "${dir}/repo"
     fi
 }
 


### PR DESCRIPTION
This allows for one .install script to call another (edeploy-roles/install-server does this) without triggering
  mount: <iso> is already mounted
