### PR TITLE
common: Remove rhel-source.repo after installation

### DIFF
--- a/build/common
+++ b/build/common
@@ -316,6 +316,7 @@ cleanup() {
         # Did we completed the build (aka no more dependencies) ?
         # It's useless creating virtualized images on dependencies, it takes space & time for nothing.
         if [ "$MAKEFILE_TARGET" = "$CLEAN_CURRENT_TARGET" ]; then
+            clean_base_repository $DIST
             echo "No more dependencies, considering Virtualized output"
             if [ ! -z "$VIRTUALIZED" ]; then
                 if [ ! -f "$VIRTUALIZED" ]; then

--- a/build/repositories
+++ b/build/repositories
@@ -314,3 +314,18 @@ disable_repository() {
         ;;
     esac
 }
+
+clean_base_repository() {
+    local dist=$1
+
+    case "$dist" in
+        $supported_debian_dists)
+        ;;
+        $supported_redhat_dists)
+            do_chroot $dir rm /etc/yum.repos.d/rhel-source.repo
+        ;;
+        *)
+            fatal_error "$(dist) isn't supported in clean_base_repository()"
+        ;;
+    esac
+}


### PR DESCRIPTION
Currently, the `rhel-source.repo` is left behind after the build.
Since it shouldn't we remove it from the generated image.
