### PR TITLE
adding qemu-img to the edeploy ansible playbook

### DIFF
--- a/ansible/edeploy-install.yml
+++ b/ansible/edeploy-install.yml
@@ -25,6 +25,8 @@
       - gcc
       - glibc.i686
       - glibc-static
+      - qemu-img
+      - patch
     when: ansible_distribution == 'CentOS' or ansible_distribution == 'RedHat'
   - name: extract eDeploy git repo
     git: repo=https://github.com/enovance/edeploy.git


### PR DESCRIPTION
I got "qemu-img is missing" during roles creation in the bootstrap process, the minimal RHEL install doesn't have this package by default.
