### PR TITLE
clean_base_repository: print a message instead of fatal_error

### DIFF
--- a/build/repositories
+++ b/build/repositories
@@ -325,7 +325,7 @@ clean_base_repository() {
             do_chroot $dir rm /etc/yum.repos.d/rhel-source.repo
         ;;
         *)
-            fatal_error "$dist isn't supported in clean_base_repository()"
+            echo "$dist isn't supported in clean_base_repository()"
         ;;
     esac
 }


### PR DESCRIPTION
This restore CentOS support
