### PR TITLE
build/base: ensure Red Hat family OS use en_US.UTF-8 locale

### DIFF
--- a/build/base.install
+++ b/build/base.install
@@ -226,6 +226,7 @@ install_base_packages() {
         rm -f "${target}"/etc/default/grub.d/edeploy.cfg
     elif [ "$(package_type)" = "rpm" ]; then
         install_packages $target "$packages"
+        do_chroot "$target" localectl set-locale LANG=en_US.UTF-8
         if [ "$CODENAME_MAJOR" = '7' ]; then
             # don't rename net ifaces
             ln -s /dev/null $dir/etc/udev/rules.d/80-net-name-slot.rules


### PR DESCRIPTION
ensure en_US.UTF-8 is the default locale on Red Hat systems, since we are already going this on Debian systems.
If not doing this, that could lead to locale issues during deployments.
