### PR TITLE
build/common: Add remote_fetch curl wrapper

### DIFF
--- a/build/common
+++ b/build/common
@@ -43,6 +43,13 @@ check_usage() {
     fi
 }
 
+remote_fetch() {
+    local remote_location=$1
+    local local_location=$2
+    # We retry 12 times with 10 seconds delay between retries
+    curl --silent --show-error --retry 12 --retry-delay 10 -L -o ${dir}/$local_location $remote_location
+}
+
 install_mellanox() {
     RELEASE=$1
     CHROOT=$2


### PR DESCRIPTION
This patch purpose remote_fetch in order to make curl/wget usage
consistent between calls. The main point is to use the curl retry
mechanism to bypass temporary remote failures.

This can be a start point to make our build process resilient to upstream failure ...
Let us know your thoughts about that. We start to use it to build SF images. 
